### PR TITLE
Fix blank email placeholder

### DIFF
--- a/profile/exops/tests/test_templates.py
+++ b/profile/exops/tests/test_templates.py
@@ -30,4 +30,4 @@ def test_email_alert_without_term():
     }
     html = render_to_string('exops/is-exops-user-email-alerts.html', context)
 
-    assert '<empty>' in html
+    assert '&lt;empty&gt;' in html

--- a/profile/templates/exops/is-exops-user-email-alerts.html
+++ b/profile/templates/exops/is-exops-user-email-alerts.html
@@ -21,7 +21,7 @@
 				<div class="sso-profile-eig-email-alert-item">
 					<div class="sso-profile-eig-email-alert-item-search-term-label" >Search term:</div>
 					<div class="sso-profile-eig-email-alert-item-search-term">
-						<span class="sso-profile-pill-button">{{ alert.term|default:'<empty>' }}</span>
+						<span class="sso-profile-pill-button">{{ alert.term|default:'&lt;empty&gt;' }}</span>
 					</div>
 					<div>
 						<strong>Alert created on: </strong><span>{{ alert.created_on|parse_date:"%Y-%m-%dT%H:%M:%S.%fZ"|date:"d F Y" }}</span>


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-1371)

The browser was interpreting `<blank>` as a html element, and upgrading it to `<blank></blank>`