### PR TITLE
Hide individual account interstitial if intent is create a business profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - TT-1636 - please select pick lists tickets include TT-1638, TT-1640,  TT-1636
 - No ticket - Increase flake 8 coverage to 120 lines
 - TT-1561 - Show different enrolment title depending on user journey
+- TT-1560 - Hide individual account interstitial if intent is create a business profile
 
 ### Fixed bugs:
 - TT-1647 - Correcting long address not displayed correctly on business search page

--- a/enrolment/templates/enrolment/individual-interstitial.html
+++ b/enrolment/templates/enrolment/individual-interstitial.html
@@ -13,13 +13,22 @@
           <div class="column-two-thirds">
               <a href="{% url 'enrolment-business-type' %}" class="link">Back</a>
               <h1 class="heading-xlarge margin-bottom-15 margin-top-15">You cannot {{ user_journey_verb }}</h1>
-              <p class="margin-bottom-30">Only UK business representatives can {{ user_journey_verb }}, but you can still update your details and use other services.</p>
-              <a class="link margin-top-15" href="{% url 'enrolment-individual' step='personal-details' %}">Update your details</a>
-              <ul class="margin-top-30">
-                <li><a class="link" href="{{ services_urls.exopps }}">Find export opportunities</a></li>
-                <li><a class="link" href="{{ services_urls.soo }}">Find online marketplaces</a></li>
-                <li><a class="link" href="{{ services_urls.great_domestic }}">Go back to great.gov.uk home</a></li>
-              </ul>
+              
+              {% if user.has_user_profile %}
+                <p class="margin-bottom-30">Only UK business representatives can {{ user_journey_verb }}, but you can still update your details and use other services.</p>
+                <a class="link margin-top-15" href="{% url 'find-a-buyer-personal-details' %}">Update your details</a>
+                <ul class="margin-top-30">
+                  <li><a class="link" href="{{ services_urls.exopps }}">Find export opportunities</a></li>
+                  <li><a class="link" href="{{ services_urls.soo }}">Find online marketplaces</a></li>
+                  <li><a class="link" href="{{ services_urls.great_domestic }}">Go back to great.gov.uk home</a></li>
+                </ul>
+              {% else %}
+                <p class="margin-bottom-30">Only UK business representatives can {{ user_journey_verb }}, but you can still create an account for individual and use other services.</p>
+                <a class="link margin-top-15" href="{% url 'enrolment-individual' step='user-account' %}">Continue creating account for individual</a>
+                <ul class="margin-top-0">
+                  <li><a class="link" href="{{ services_urls.great_domestic }}">Go back to great.gov.uk home</a></li>
+                </ul>     
+              {% endif %}
           </div>
       </div>
   </section>


### PR DESCRIPTION

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] Add a printscreen to the PR

## User clicked "sign in" in the header
_User is not shown the interstitial. Page shows "create great.gov.uk account"_
![header-login](https://user-images.githubusercontent.com/5485798/62140529-0c962e80-b2e3-11e9-94f6-11594abce30c.gif)

## User clicked "start now" then logs in
_User is shown the "update details" interstitial. Page shows "create business profile"_
![start-now-log-in](https://user-images.githubusercontent.com/5485798/62140553-1a4bb400-b2e3-11e9-81bc-de6276741018.gif)

## User clicked "start now" then creates account
_User is shown the "create" interstitial. Page shows "create business profile"_
![start-now-create](https://user-images.githubusercontent.com/5485798/62140539-115ae280-b2e3-11e9-94d4-72b73b3d67ea.gif)

