### PR TITLE
Autoformat minor fixups

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -87,7 +87,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.messages.context_processors.messages',
                 'directory_components.context_processors.urls_processor',
-                ('directory_components.context_processors.' 'header_footer_processor'),
+                'directory_components.context_processors.header_footer_processor',
                 'directory_components.context_processors.sso_processor',
                 'directory_components.context_processors.ga360',
                 'directory_components.context_processors.analytics',

--- a/enrolment/forms.py
+++ b/enrolment/forms.py
@@ -35,11 +35,11 @@ class BusinessType(forms.Form):
     CHOICES = (
         (
             constants.COMPANIES_HOUSE_COMPANY,
-            ('I represent a limited company (Ltd), a public limited  ' 'company (PLC) or a Royal Charter company'),
+            ('I represent a limited company (Ltd), a public limited company (PLC) or a Royal Charter company'),
         ),
         (
             constants.NON_COMPANIES_HOUSE_COMPANY,
-            ("I'm a sole trader or I represent another type of UK " 'business not registered with Companies House'),
+            ("I'm a sole trader or I represent another type of UK business not registered with Companies House"),
         ),
         (constants.NOT_COMPANY, ('I pay taxes in the UK but do not represent a business')),
         (constants.OVERSEAS_COMPANY, ('My business or organisation is not registered in the UK')),
@@ -126,7 +126,7 @@ class UserAccountVerification(forms.Form):
 
 class CompaniesHouseCompanySearch(forms.Form):
     MESSAGE_COMPANY_NOT_FOUND = (
-        '<p>Your business name is not listed.</p>' "<p>Check that you've entered the right name.</p>"
+        "<p>Your business name is not listed.</p><p>Check that you've entered the right name.</p>"
     )
     MESSAGE_COMPANY_NOT_ACTIVE = 'Company not active.'
     company_name = forms.CharField(label='Registered company name')

--- a/profile/business_profile/forms.py
+++ b/profile/business_profile/forms.py
@@ -86,7 +86,7 @@ class CaseStudyBasicInfoForm(forms.Form):
     )
     description = forms.CharField(
         label='Describe your case study or project',
-        help_text=('Describe your project or case study in greater detail. ' 'You have up to 1,000 characters to use.'),
+        help_text=('Describe your project or case study in greater detail. You have up to 1,000 characters to use.'),
         max_length=1000,
         validators=[validators.does_not_contain_email, directory_validators.string.no_html],
         widget=Textarea,
@@ -104,7 +104,7 @@ class CaseStudyBasicInfoForm(forms.Form):
             'study or project. Keywords should be separated by '
             'commas.'
         ),
-        help_text=('These keywords will help potential overseas buyers ' 'find your case study.'),
+        help_text=('These keywords will help potential overseas buyers find your case study.'),
         max_length=1000,
         widget=Textarea,
         validators=[
@@ -190,7 +190,7 @@ class CaseStudyRichMediaForm(DynamicHelptextFieldsMixin, forms.Form):
         validators=[directory_validators.file.case_study_image_filesize, directory_validators.file.image_format],
     )
     image_two_caption = forms.CharField(
-        label=('Add a caption that tells visitors what this second image ' 'represents'),
+        label=('Add a caption that tells visitors what this second image represents'),
         help_text='Maximum 120 characters',
         max_length=120,
         widget=Textarea,
@@ -202,7 +202,7 @@ class CaseStudyRichMediaForm(DynamicHelptextFieldsMixin, forms.Form):
         validators=[directory_validators.file.case_study_image_filesize, directory_validators.file.image_format],
     )
     image_three_caption = forms.CharField(
-        label=('Add a caption that tells visitors what this third image ' 'represents'),
+        label=('Add a caption that tells visitors what this third image represents'),
         help_text='Maximum 120 characters',
         max_length=120,
         widget=Textarea,
@@ -246,9 +246,7 @@ class CaseStudyRichMediaForm(DynamicHelptextFieldsMixin, forms.Form):
 
 class LogoForm(forms.Form):
     logo = ImageField(
-        help_text=(
-            'For best results this should be a transparent PNG file of 600 x ' '600 pixels and no more than 2MB'
-        ),
+        help_text=('For best results this should be a transparent PNG file of 600 x 600 pixels and no more than 2MB'),
         required=True,
         validators=[directory_validators.file.logo_filesize, directory_validators.file.image_format],
     )

--- a/profile/exops/tests/test_templates.py
+++ b/profile/exops/tests/test_templates.py
@@ -38,4 +38,4 @@ def test_email_alert_all_opportunities():
 
 def test_email_alert_link_region():
     html = render_html([{'created_on': '2000-01-01T01:01:01.000001Z', 'countries': ['Greece', 'Italy']}])
-    assert 'href="?suppress_subscription_block=true&s=&' 'countries[]=Greece&countries[]=Italy' in html
+    assert 'href="?suppress_subscription_block=true&s=&countries[]=Greece&countries[]=Italy' in html

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -13,5 +13,5 @@ pytest-xdist
 black==20.8b1
 blacken-docs==1.6.0
 isort==5.6.4
-flake8==3.3.0
+flake8==3.8.4
 pre-commit-hooks==3.3.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -38,11 +38,11 @@ django==2.2.13            # via -r requirements.in, directory-api-client, direct
 djangorestframework==3.9.4  # via -r requirements.in, sigauth
 docutils==0.15.2          # via botocore
 execnet==1.7.1            # via pytest-xdist
-flake8==3.3.0             # via -r requirements_test.in
+flake8==3.8.4             # via -r requirements_test.in
 freezegun==0.3.12         # via -r requirements_test.in
 gunicorn==19.5.0          # via -r requirements.in
 idna==2.8                 # via requests
-importlib-metadata==0.23  # via pluggy, pytest
+importlib-metadata==0.23  # via flake8, pluggy, pytest
 isort==5.6.4              # via -r requirements_test.in
 jmespath==0.9.4           # via boto3, botocore
 jsonschema==3.0.2         # via directory-components
@@ -58,8 +58,8 @@ pillow==7.2.0             # via directory-validators
 pluggy==0.13.0            # via pytest
 pre-commit-hooks==3.3.0   # via -r requirements_test.in
 py==1.8.0                 # via pytest, pytest-catchlog
-pycodestyle==2.3.1        # via flake8
-pyflakes==1.5.0           # via flake8
+pycodestyle==2.6.0        # via flake8
+pyflakes==2.2.0           # via flake8
 pyparsing==2.4.2          # via packaging
 pyrsistent==0.15.4        # via jsonschema
 pytest-catchlog==1.2.2    # via -r requirements_test.in


### PR DESCRIPTION
* Bump flake8 in requirements to the latest version (which pre-commit also expects)
* Remove unnecessary gaps between strings that were converted from multi-line to single-line by Black:

    Note that they were not failing before when they had the gap - it makes no difference to the output:

    `'Hello'  'World'` and `'Hello World'`  are both output as `'Hello World'`

    However, this change makes things neater and less puzzling for developers