### PR TITLE
GP2-2381: update directory-components to fix magna-footer contact URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@
 ## Pre-Release
 
 ### Implemented enhancements
+ - GP2-2381 - corrected footer link for contact
  - GP2-2332 - Upgraded directory-components package
  - No ticket - Dependencies upgrade
- * GP2-2224 - Python upgrade to 3.9.1
- 
+ - GP2-2224 - Python upgrade to 3.9.1
+
 ### Fixed bugs
-- 
+-
 - GBAU-889 - directory-components version bump
 - GAA-27 - directory-components version bump
 - GP2-1068 - adopt Black auto-formatting + provide optional pre-commit config

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ requests==2.21.0
 whitenoise==4.1.2
 sigauth==4.1.0
 directory-validators==6.0.5
-directory-components==36.1.0
+directory-components==36.2.0
 urllib3>=1.24.2<2.0.0
 django-formtools==2.1
 django-recaptcha==2.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,9 +30,9 @@ directory-client-core==6.3.0
     #   directory-ch-client
     #   directory-forms-api-client
     #   directory-sso-api-client
-directory-components==36.1.0
+directory-components==36.2.0
     # via -r requirements.in
-directory-constants==20.27.0
+directory-constants==20.28.0
     # via directory-components
 directory-forms-api-client==5.0.0
     # via -r requirements.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -50,9 +50,9 @@ directory-client-core==6.3.0
     #   directory-ch-client
     #   directory-forms-api-client
     #   directory-sso-api-client
-directory-components==36.1.0
+directory-components==36.2.0
     # via -r requirements.in
-directory-constants==20.27.0
+directory-constants==20.28.0
     # via directory-components
 directory-forms-api-client==5.0.0
     # via -r requirements.in


### PR DESCRIPTION
Small bump to get /contact-us/ changed to /contact/

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if updating requirements) Requirements have been compiled.